### PR TITLE
Sample-log cache + single per-batch record callback, with a stage-wise rollout evaluation and target-violation share

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ DecisionRules.train_multiple_shooting(
 
 Evaluating a trained policy only through the deterministic equivalent can overstate its quality: the coupled solve re-optimizes all stages jointly and absorbs targets that are not followable stage by stage through the slack penalty — exactly what deployment cannot do. The stage-wise rollout is the deployment semantics of a target-trajectory policy, so report it as the headline metric, together with a target-violation measure.
 
-The training loops record metrics through a per-sample `SampleLog` cache and a per-batch `record(sample_log, iter, model)` callback. `RolloutEvaluation` is a ready-made `record` implementation that evaluates the policy stage-wise on a fixed held-out scenario set:
+The training loops record metrics through a per-sample `SampleLog` cache and a per-batch `record(sample_log, iter, model)` callback. `RolloutEvaluation` is a ready-made helper that evaluates the policy stage-wise on a fixed held-out scenario set; call it from within `record`:
 
 ```julia
 using DecisionRules, Random
@@ -176,7 +176,11 @@ rollout_eval = RolloutEvaluation(
 )
 
 train_multistage(policy, initial_state, det, state_in_det, state_out_det, uncertainty_sampler;
-    num_batches=100, record=rollout_eval)
+    num_batches=100,
+    record=(sample_log, iter, model) -> begin
+        rollout_eval(iter, model)
+        return false
+    end)
 ```
 
 Each evaluation reports (a) the rollout objective **excluding** the target-slack penalty term (the operational cost) and (b) the **target-violation share** — the realized slack penalty divided by the full objective. Policy comparisons are only trustworthy when the violation share is small (≤ ~0.05): a larger share means the policy's targets are not followable stage by stage and the reported cost is not what deployment would realize. When training drives the violation share to ~0, the deterministic-equivalent and rollout views are expected to coincide; the rollout metric is the guard that detects when they don't.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,32 @@ DecisionRules.train_multiple_shooting(
 )
 ```
 
+## Evaluation: stage-wise rollout and target-violation share
+
+Evaluating a trained policy only through the deterministic equivalent can overstate its quality: the coupled solve re-optimizes all stages jointly and absorbs targets that are not followable stage by stage through the slack penalty — exactly what deployment cannot do. The stage-wise rollout is the deployment semantics of a target-trajectory policy, so report it as the headline metric, together with a target-violation measure.
+
+The training loops record metrics through a per-sample `SampleLog` cache and a per-batch `record(sample_log, iter, model)` callback. `RolloutEvaluation` is a ready-made `record` implementation that evaluates the policy stage-wise on a fixed held-out scenario set:
+
+```julia
+using DecisionRules, Random
+
+# Materialize a FIXED held-out evaluation set once, before training
+Random.seed!(1234)
+eval_scenarios = [DecisionRules.sample(uncertainty_samples) for _ in 1:8]
+
+rollout_eval = RolloutEvaluation(
+    subproblems, state_params_in, state_params_out, initial_state, eval_scenarios;
+    stride=25,  # evaluate every 25 batches
+)
+
+train_multistage(policy, initial_state, det, state_in_det, state_out_det, uncertainty_sampler;
+    num_batches=100, record=rollout_eval)
+```
+
+Each evaluation reports (a) the rollout objective **excluding** the target-slack penalty term (the operational cost) and (b) the **target-violation share** — the realized slack penalty divided by the full objective. Policy comparisons are only trustworthy when the violation share is small (≤ ~0.05): a larger share means the policy's targets are not followable stage by stage and the reported cost is not what deployment would realize. When training drives the violation share to ~0, the deterministic-equivalent and rollout views are expected to coincide; the rollout metric is the guard that detects when they don't.
+
+Per-sample debugging hooks can be attached with `SampleLog(on_sample=(s, models, log) -> ...)`; the training loop calls the hook after each sample's solve with the live JuMP model(s). The previous `record_loss=(iter, model, loss, tag) -> ...` keyword keeps working as a deprecated adapter.
+
 ## Examples and tests
 
 Examples live in `examples/`. Run tests with:

--- a/examples/HydroPowerModels/train_dr_hydropowermodels_subproblems.jl
+++ b/examples/HydroPowerModels/train_dr_hydropowermodels_subproblems.jl
@@ -45,6 +45,8 @@ optimizers= [Flux.Adam()] # Flux.Adam(0.01), Flux.Descent(0.1), Flux.RMSProp(0.0
 pre_trained_model = nothing #joinpath(HydroPowerModels_dir, case_name, formulation, "models", "case3-ACPPowerModel-h48-2024-05-18T10:16:25.117.jld2")
 penalty_l2 = :auto
 penalty_l1 = :auto
+num_eval_scenarios = 4                   # fixed held-out scenarios for the rollout evaluation
+eval_every = 25                          # rollout-evaluate every eval_every batches
 
 # Build MSP using subproblems (not deterministic equivalent)
 
@@ -85,11 +87,6 @@ lg = WandbLogger(
     )
 )
 
-function record_loss(iter, model, loss, tag)
-    Wandb.log(lg, Dict(tag => loss))
-    return false
-end
-
 # Define Model
 # Policy architecture: LSTM processes uncertainty, Dense combines with previous state
 num_uncertainties = length(uncertainty_samples[1])
@@ -116,6 +113,16 @@ model_path = joinpath(model_dir, save_file * ".jld2")
 save_control = SaveBest(best_obj, model_path)
 convergence_criterium = StallingCriterium(100, best_obj, 0)
 
+# Fixed held-out scenarios, materialized once so every evaluation uses the same set.
+# The rollout evaluation executes the policy stage by stage (deployment semantics) and
+# reports the operational cost (objective excluding the target-slack penalty) plus the
+# target-violation share; comparisons are only trustworthy when the share is <= ~0.05.
+Random.seed!(8789)
+eval_scenarios = [DecisionRules.sample(uncertainty_samples) for _ in 1:num_eval_scenarios]
+rollout_evaluation = RolloutEvaluation(subproblems, state_params_in, state_params_out,
+    initial_state, eval_scenarios; stride=eval_every,
+    record=(sample_log, iter, model) -> false)
+
 adjust_hyperparameters = (iter, opt_state, num_train_per_batch) -> begin
     if iter % 2100 == 0
         num_train_per_batch = num_train_per_batch * 2
@@ -130,13 +137,21 @@ for iter in 1:num_epochs
         num_batches=num_batches,
         num_train_per_batch=num_train_per_batch,
         optimizer=optimizers[floor(min(iter, length(optimizers)))],
-        record_loss= (iter, model, loss, tag) -> begin
-            if tag == "metrics/training_loss"
-                save_control(iter, model, loss)
-                record_loss(iter, model, loss, tag)
-                return convergence_criterium(iter, model, loss)
+        record=(sample_log, iter, model) -> begin
+            training_loss = mean(sample_log.objectives)
+            Wandb.log(lg, Dict(
+                "metrics/loss" => mean(sample_log.objectives_no_deficit),
+                "metrics/training_loss" => training_loss,
+            ))
+            rollout_evaluation(sample_log, iter, model)
+            if iter % eval_every == 0
+                Wandb.log(lg, Dict(
+                    "metrics/rollout_objective_no_deficit" => rollout_evaluation.last_objective_no_deficit,
+                    "metrics/rollout_target_violation_share" => rollout_evaluation.last_violation_share,
+                ))
             end
-            return record_loss(iter, model, loss, tag)
+            save_control(iter, model, training_loss)
+            return convergence_criterium(iter, model, training_loss)
         end,
         # ensure_feasibility=(x_out, x_in, uncertainty) -> ensure_feasibility(x_out, x_in, uncertainty, max_volume),
         adjust_hyperparameters=adjust_hyperparameters

--- a/examples/HydroPowerModels/train_dr_hydropowermodels_subproblems.jl
+++ b/examples/HydroPowerModels/train_dr_hydropowermodels_subproblems.jl
@@ -120,8 +120,7 @@ convergence_criterium = StallingCriterium(100, best_obj, 0)
 Random.seed!(8789)
 eval_scenarios = [DecisionRules.sample(uncertainty_samples) for _ in 1:num_eval_scenarios]
 rollout_evaluation = RolloutEvaluation(subproblems, state_params_in, state_params_out,
-    initial_state, eval_scenarios; stride=eval_every,
-    record=(sample_log, iter, model) -> false)
+    initial_state, eval_scenarios; stride=eval_every)
 
 adjust_hyperparameters = (iter, opt_state, num_train_per_batch) -> begin
     if iter % 2100 == 0
@@ -143,7 +142,7 @@ for iter in 1:num_epochs
                 "metrics/loss" => mean(sample_log.objectives_no_deficit),
                 "metrics/training_loss" => training_loss,
             ))
-            rollout_evaluation(sample_log, iter, model)
+            rollout_evaluation(iter, model)
             if iter % eval_every == 0
                 Wandb.log(lg, Dict(
                     "metrics/rollout_objective_no_deficit" => rollout_evaluation.last_objective_no_deficit,

--- a/src/DecisionRules.jl
+++ b/src/DecisionRules.jl
@@ -10,7 +10,8 @@ import ChainRulesCore.rrule
 using DiffOpt
 using Logging
 
-export simulate_multistage, sample, train_multistage, simulate_states, simulate_stage, dense_multilayer_nn, variable_to_parameter, create_deficit!, 
+export simulate_multistage, sample, train_multistage, simulate_states, simulate_stage, dense_multilayer_nn, variable_to_parameter, create_deficit!,
+    SampleLog, default_record, RolloutEvaluation,
     SaveBest, find_variables, compute_parameter_dual, StallingCriterium, policy_input_dim, normalize_recur_state,
     StateConditionedPolicy, state_conditioned_policy, materialize_tangent,
     # Multiple shooting exports

--- a/src/simulate_multistage.jl
+++ b/src/simulate_multistage.jl
@@ -339,15 +339,16 @@ function sample(uncertainty_samples::Vector{Vector{Tuple{VariableRef, Vector{T}}
     [sample(uncertainty_samples[t]) for t in 1:length(uncertainty_samples)]
 end
 
-function train_multistage(model, initial_state, subproblems::Vector{JuMP.Model}, 
-    state_params_in, state_params_out, uncertainty_sampler; 
+function train_multistage(model, initial_state, subproblems::Vector{JuMP.Model},
+    state_params_in, state_params_out, uncertainty_sampler;
     num_batches=100, num_train_per_batch=32, optimizer=Flux.Adam(0.01),
     adjust_hyperparameters=(iter, opt_state, num_train_per_batch) -> num_train_per_batch,
-    record_loss=(iter, model, loss, tag) -> begin println("tag: $tag, Iter: $iter, Loss: $loss")
-        return false
-    end,
-    get_objective_no_target_deficit=get_objective_no_target_deficit
+    record_loss=nothing,
+    get_objective_no_target_deficit=get_objective_no_target_deficit,
+    sample_log=SampleLog(objective_no_deficit_fn=get_objective_no_target_deficit),
+    record=default_record
 )
+    record = _resolve_record(record, record_loss)
     # Initialise the optimiser for this model:
     opt_state = Flux.setup(optimizer, model)
 
@@ -356,19 +357,17 @@ function train_multistage(model, initial_state, subproblems::Vector{JuMP.Model},
         # Sample uncertainties
         uncertainty_samples = [sample(uncertainty_sampler) for _ in 1:num_train_per_batch]
         objective = 0.0
-        eval_loss = 0.0
+        _reset_sample_log!(sample_log)
         grads = Flux.gradient(model) do m
             for s in 1:num_train_per_batch
                 Flux.reset!(m)
                 objective += simulate_multistage(subproblems, state_params_in, state_params_out, initial_state, uncertainty_samples[s], m)
-                eval_loss += get_objective_no_target_deficit(subproblems)
+                @ignore_derivatives sample_log(s, subproblems)
             end
             objective /= num_train_per_batch
-            eval_loss /= num_train_per_batch
             return objective
         end
-        record_loss(iter, model, eval_loss, "metrics/loss") && break
-        record_loss(iter, model, objective, "metrics/training_loss") && break
+        record(sample_log, iter, model) && break
 
         # Update the parameters so as to reduce the objective,
         # according the chosen optimisation rule:
@@ -393,15 +392,16 @@ function sim_states(t, m, initial_state, uncertainty_sample_vec, prev_states)
     end
 end
 
-function train_multistage(model, initial_state, det_equivalent::JuMP.Model, 
-    state_params_in, state_params_out, uncertainty_sampler; 
+function train_multistage(model, initial_state, det_equivalent::JuMP.Model,
+    state_params_in, state_params_out, uncertainty_sampler;
     num_batches=100, num_train_per_batch=32, optimizer=Flux.Adam(0.01),
     adjust_hyperparameters=(iter, opt_state, num_train_per_batch) -> num_train_per_batch,
-    record_loss=(iter, model, loss, tag) -> begin println("tag: $tag, Iter: $iter, Loss: $loss")
-        return false
-    end,
-    get_objective_no_target_deficit=get_objective_no_target_deficit
+    record_loss=nothing,
+    get_objective_no_target_deficit=get_objective_no_target_deficit,
+    sample_log=SampleLog(objective_no_deficit_fn=get_objective_no_target_deficit),
+    record=default_record
 )
+    record = _resolve_record(record, record_loss)
     # Initialise the optimiser for this model:
     opt_state = Flux.setup(optimizer, model)
     num_stages = length(state_params_in)
@@ -416,7 +416,7 @@ function train_multistage(model, initial_state, det_equivalent::JuMP.Model,
         # Calculate the gradient of the objective
         # with respect to the parameters within the model:
         objective = 0.0
-        eval_loss = 0.0
+        _reset_sample_log!(sample_log)
         # try
             grads = Flux.gradient(model) do m
                 for s in 1:num_train_per_batch
@@ -431,17 +431,15 @@ function train_multistage(model, initial_state, det_equivalent::JuMP.Model,
                     # Combine initial state with predicted states
                     states = vcat([init_state], predicted_states)
                     objective += simulate_multistage(det_equivalent, state_params_in, state_params_out, uncertainty_samples[s], states)
-                    eval_loss += get_objective_no_target_deficit(det_equivalent)
+                    @ignore_derivatives sample_log(s, det_equivalent)
                 end
                 objective /= num_train_per_batch
-                eval_loss /= num_train_per_batch
                 return objective
             end
         # catch
             # continue;
         # end
-        record_loss(iter, model, eval_loss, "metrics/loss") && break
-        record_loss(iter, model, objective, "metrics/training_loss") && break
+        record(sample_log, iter, model) && break
 
         # Update the parameters so as to reduce the objective,
         # according the chosen optimisation rule:

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -158,6 +158,186 @@ function (callback::StallingCriterium)(iter, model, loss)
     return false
 end
 
+"""
+    SampleLog(; on_sample=(s, models, sample_log) -> nothing,
+              objective_no_deficit_fn=get_objective_no_target_deficit)
+
+Per-sample logger with local cache state for the training loops, patterned after
+[`SaveBest`](@ref SaveBest). During each batch the training loop calls
+`sample_log(s, det_equivalent_or_subproblems)` right after sample `s` has been simulated
+(successful solves only; a failed solve throws exactly as before). The default behavior
+caches, per sample, the full objective (`objective_value`) and the objective excluding
+the target-slack penalty term (`objective_no_deficit_fn`). The cache is cleared at the
+start of every batch and handed to the per-batch `record(sample_log, iter, model)`
+callback.
+
+`on_sample` is an optional hook called as `on_sample(s, models, sample_log)` after the
+default caching. It receives the live JuMP model(s), so it can inspect termination
+statuses or dump the details of a suspicious sample for debugging — without paying any
+per-sample logging cost in the default configuration.
+"""
+mutable struct SampleLog <: Function
+    on_sample::Function
+    objective_no_deficit_fn::Function
+    objectives::Vector{Float64}
+    objectives_no_deficit::Vector{Float64}
+end
+
+function SampleLog(; on_sample=(s, models, sample_log) -> nothing,
+                   objective_no_deficit_fn=get_objective_no_target_deficit)
+    return SampleLog(on_sample, objective_no_deficit_fn, Float64[], Float64[])
+end
+
+function Base.empty!(sample_log::SampleLog)
+    empty!(sample_log.objectives)
+    empty!(sample_log.objectives_no_deficit)
+    return sample_log
+end
+
+_reset_sample_log!(sample_log::SampleLog) = empty!(sample_log)
+_reset_sample_log!(sample_log) = sample_log
+
+_total_objective_value(model::JuMP.Model) = objective_value(model)
+function _total_objective_value(models::Vector{JuMP.Model})
+    total = 0.0
+    for model in models
+        total += objective_value(model)
+    end
+    return total
+end
+
+function (sample_log::SampleLog)(s::Int, models)
+    push!(sample_log.objectives, _total_objective_value(models))
+    push!(sample_log.objectives_no_deficit, sample_log.objective_no_deficit_fn(models))
+    sample_log.on_sample(s, models, sample_log)
+    return nothing
+end
+
+# Sequential accumulation keeps the same floating-point summation order as the
+# historical `loss += ...; loss /= n` pattern inside the training loops.
+function _sequential_mean(values)
+    total = 0.0
+    for v in values
+        total += v
+    end
+    return total / length(values)
+end
+
+"""
+    default_record(sample_log, iter, model)
+
+Default per-batch recording callback: prints the same two per-batch lines as the
+historical `record_loss` default (`metrics/loss` = mean objective excluding the
+target-slack penalty, then `metrics/training_loss` = mean full objective) and returns
+`false` (training continues). Return `true` from a custom `record` to stop training.
+"""
+function default_record(sample_log::SampleLog, iter, model)
+    println("tag: metrics/loss, Iter: $iter, Loss: $(_sequential_mean(sample_log.objectives_no_deficit))")
+    println("tag: metrics/training_loss, Iter: $iter, Loss: $(_sequential_mean(sample_log.objectives))")
+    return false
+end
+
+# Adapter for the deprecated 4-argument `record_loss(iter, model, loss, tag)` interface.
+# Reproduces the historical two-call contract exactly, including the short-circuit:
+# the "metrics/loss" call runs first and, if it requests a stop, the
+# "metrics/training_loss" call never happens.
+function _record_loss_adapter(record_loss)
+    return function (sample_log::SampleLog, iter, model)
+        record_loss(iter, model, _sequential_mean(sample_log.objectives_no_deficit), "metrics/loss") && return true
+        return record_loss(iter, model, _sequential_mean(sample_log.objectives), "metrics/training_loss")
+    end
+end
+
+function _resolve_record(record, record_loss)
+    isnothing(record_loss) && return record
+    record === default_record || throw(ArgumentError("pass either `record` or the deprecated `record_loss`, not both"))
+    return _record_loss_adapter(record_loss)
+end
+
+"""
+    _target_violation_share(objective, objective_no_deficit)
+
+Target-violation share: the realized target-slack penalty divided by the full
+objective. Returns `NaN` when the share is undefined (nonfinite inputs or a full
+objective of magnitude ~0).
+"""
+function _target_violation_share(objective::Real, objective_no_deficit::Real)
+    slack = objective - objective_no_deficit
+    (isfinite(objective) && isfinite(slack) && abs(objective) > 1e-12) || return NaN
+    return slack / objective
+end
+
+"""
+    RolloutEvaluation(subproblems, state_params_in, state_params_out, initial_state,
+                      scenarios; stride=1, record=default_record)
+
+Ready-made `record` callback that evaluates the policy with a **stage-wise rollout**
+(the deployment semantics of a target-trajectory policy) on a fixed held-out scenario
+set. Deterministic-equivalent evaluation re-optimizes all stages jointly and can absorb
+stage-wise-unfollowable targets through the slack penalty, silently overstating policy
+quality; the rollout metric is the guard that detects this.
+
+`scenarios` must be a vector of **materialized** scenarios, sampled once before
+training (e.g. `[DecisionRules.sample(uncertainty_samples) for _ in 1:n]`), so every
+evaluation uses the same fixed set. `subproblems` may be the training subproblems (all
+stage parameters are rewritten on every solve) or a separately built copy; when
+training on a deterministic equivalent, pass the stage-wise subproblems here.
+
+Every `stride` batches the callback reports, over the fixed set:
+
+- `metrics/rollout_objective_no_deficit`: the rollout objective excluding the
+  target-slack penalty term (the operational cost), and
+- `metrics/rollout_target_violation_share`: the realized slack penalty divided by the
+  full rollout objective (`NaN` when undefined).
+
+Policy comparisons should only be trusted when the violation share is small
+(≤ ~0.05); a larger share means the policy's targets are not followable stage by stage
+and the reported cost is not what deployment would realize. The latest values are kept
+in `last_objective_no_deficit` / `last_violation_share` for custom logging.
+
+The wrapped `record` callback (default [`default_record`](@ref default_record)) runs
+first each batch and its return value decides early stopping.
+"""
+mutable struct RolloutEvaluation <: Function
+    subproblems::Vector{JuMP.Model}
+    state_params_in
+    state_params_out
+    initial_state
+    scenarios::Vector
+    stride::Int
+    record::Function
+    last_objective_no_deficit::Float64
+    last_violation_share::Float64
+end
+
+function RolloutEvaluation(subproblems, state_params_in, state_params_out, initial_state,
+                           scenarios; stride=1, record=default_record)
+    isempty(scenarios) && throw(ArgumentError(
+        "scenarios must be a nonempty vector of materialized scenarios; sample them once before training so every evaluation uses the same fixed set"))
+    stride >= 1 || throw(ArgumentError("stride must be >= 1"))
+    return RolloutEvaluation(subproblems, state_params_in, state_params_out, initial_state,
+        collect(scenarios), stride, record, NaN, NaN)
+end
+
+function (evaluation::RolloutEvaluation)(sample_log, iter, model)
+    stop = evaluation.record(sample_log, iter, model)
+    if iter % evaluation.stride == 0
+        total = 0.0
+        total_no_deficit = 0.0
+        for scenario in evaluation.scenarios
+            total += simulate_multistage(evaluation.subproblems, evaluation.state_params_in,
+                evaluation.state_params_out, evaluation.initial_state, scenario, model)
+            total_no_deficit += get_objective_no_target_deficit(evaluation.subproblems)
+        end
+        objective = total / length(evaluation.scenarios)
+        evaluation.last_objective_no_deficit = total_no_deficit / length(evaluation.scenarios)
+        evaluation.last_violation_share = _target_violation_share(objective, evaluation.last_objective_no_deficit)
+        println("tag: metrics/rollout_objective_no_deficit, Iter: $iter, Loss: $(evaluation.last_objective_no_deficit)")
+        println("tag: metrics/rollout_target_violation_share, Iter: $iter, Loss: $(evaluation.last_violation_share)")
+    end
+    return stop
+end
+
 function var_set_name!(src::JuMP.VariableRef, dest::JuMP.VariableRef, t::Int)
     name = JuMP.name(src)
     if !isempty(name)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -269,11 +269,11 @@ end
 
 """
     RolloutEvaluation(subproblems, state_params_in, state_params_out, initial_state,
-                      scenarios; stride=1, record=default_record)
+                      scenarios; stride=1)
 
-Ready-made `record` callback that evaluates the policy with a **stage-wise rollout**
-(the deployment semantics of a target-trajectory policy) on a fixed held-out scenario
-set. Deterministic-equivalent evaluation re-optimizes all stages jointly and can absorb
+Evaluation helper that assesses the policy with a **stage-wise rollout** (the
+deployment semantics of a target-trajectory policy) on a fixed held-out scenario set.
+Deterministic-equivalent evaluation re-optimizes all stages jointly and can absorb
 stage-wise-unfollowable targets through the slack penalty, silently overstating policy
 quality; the rollout metric is the guard that detects this.
 
@@ -283,7 +283,8 @@ evaluation uses the same fixed set. `subproblems` may be the training subproblem
 stage parameters are rewritten on every solve) or a separately built copy; when
 training on a deterministic equivalent, pass the stage-wise subproblems here.
 
-Every `stride` batches the callback reports, over the fixed set:
+Call `evaluation(iter, model)`, e.g. from within a `record` callback. Every `stride`
+calls it rolls the policy out over the fixed set and reports:
 
 - `metrics/rollout_objective_no_deficit`: the rollout objective excluding the
   target-slack penalty term (the operational cost), and
@@ -293,10 +294,9 @@ Every `stride` batches the callback reports, over the fixed set:
 Policy comparisons should only be trusted when the violation share is small
 (≤ ~0.05); a larger share means the policy's targets are not followable stage by stage
 and the reported cost is not what deployment would realize. The latest values are kept
-in `last_objective_no_deficit` / `last_violation_share` for custom logging.
-
-The wrapped `record` callback (default [`default_record`](@ref default_record)) runs
-first each batch and its return value decides early stopping.
+in `last_objective_no_deficit` / `last_violation_share` for custom logging. Calls on
+batches that are not a multiple of `stride` are a no-op and leave the cached values
+unchanged.
 """
 mutable struct RolloutEvaluation <: Function
     subproblems::Vector{JuMP.Model}
@@ -305,37 +305,34 @@ mutable struct RolloutEvaluation <: Function
     initial_state
     scenarios::Vector
     stride::Int
-    record::Function
     last_objective_no_deficit::Float64
     last_violation_share::Float64
 end
 
 function RolloutEvaluation(subproblems, state_params_in, state_params_out, initial_state,
-                           scenarios; stride=1, record=default_record)
+                           scenarios; stride=1)
     isempty(scenarios) && throw(ArgumentError(
         "scenarios must be a nonempty vector of materialized scenarios; sample them once before training so every evaluation uses the same fixed set"))
     stride >= 1 || throw(ArgumentError("stride must be >= 1"))
     return RolloutEvaluation(subproblems, state_params_in, state_params_out, initial_state,
-        collect(scenarios), stride, record, NaN, NaN)
+        collect(scenarios), stride, NaN, NaN)
 end
 
-function (evaluation::RolloutEvaluation)(sample_log, iter, model)
-    stop = evaluation.record(sample_log, iter, model)
-    if iter % evaluation.stride == 0
-        total = 0.0
-        total_no_deficit = 0.0
-        for scenario in evaluation.scenarios
-            total += simulate_multistage(evaluation.subproblems, evaluation.state_params_in,
-                evaluation.state_params_out, evaluation.initial_state, scenario, model)
-            total_no_deficit += get_objective_no_target_deficit(evaluation.subproblems)
-        end
-        objective = total / length(evaluation.scenarios)
-        evaluation.last_objective_no_deficit = total_no_deficit / length(evaluation.scenarios)
-        evaluation.last_violation_share = _target_violation_share(objective, evaluation.last_objective_no_deficit)
-        println("tag: metrics/rollout_objective_no_deficit, Iter: $iter, Loss: $(evaluation.last_objective_no_deficit)")
-        println("tag: metrics/rollout_target_violation_share, Iter: $iter, Loss: $(evaluation.last_violation_share)")
+function (evaluation::RolloutEvaluation)(iter, model)
+    iter % evaluation.stride == 0 || return nothing
+    total = 0.0
+    total_no_deficit = 0.0
+    for scenario in evaluation.scenarios
+        total += simulate_multistage(evaluation.subproblems, evaluation.state_params_in,
+            evaluation.state_params_out, evaluation.initial_state, scenario, model)
+        total_no_deficit += get_objective_no_target_deficit(evaluation.subproblems)
     end
-    return stop
+    objective = total / length(evaluation.scenarios)
+    evaluation.last_objective_no_deficit = total_no_deficit / length(evaluation.scenarios)
+    evaluation.last_violation_share = _target_violation_share(objective, evaluation.last_objective_no_deficit)
+    println("tag: metrics/rollout_objective_no_deficit, Iter: $iter, Loss: $(evaluation.last_objective_no_deficit)")
+    println("tag: metrics/rollout_target_violation_share, Iter: $iter, Loss: $(evaluation.last_violation_share)")
+    return nothing
 end
 
 function var_set_name!(src::JuMP.VariableRef, dest::JuMP.VariableRef, t::Int)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -468,15 +468,13 @@ end
             # exactly reachable at every stage and the violation share is ~0 by
             # construction.
             reachable_policy = x -> [x[1] + x[2] - 2.0]
-            rollout_eval = RolloutEvaluation(sps, spi, spo, [5.0], scenarios; stride=1,
-                record=(sample_log, iter, model) -> false)
-            @test rollout_eval(SampleLog(), 1, reachable_policy) == false
+            rollout_eval = RolloutEvaluation(sps, spi, spo, [5.0], scenarios; stride=1)
+            @test rollout_eval(1, reachable_policy) === nothing
             @test isfinite(rollout_eval.last_objective_no_deficit)
             @test abs(rollout_eval.last_violation_share) < 1.0e-4
             # stride: no evaluation on off-stride batches
-            rollout_eval2 = RolloutEvaluation(sps, spi, spo, [5.0], scenarios; stride=2,
-                record=(sample_log, iter, model) -> false)
-            rollout_eval2(SampleLog(), 1, reachable_policy)
+            rollout_eval2 = RolloutEvaluation(sps, spi, spo, [5.0], scenarios; stride=2)
+            rollout_eval2(1, reachable_policy)
             @test isnan(rollout_eval2.last_objective_no_deficit)
             @test_throws ArgumentError RolloutEvaluation(sps, spi, spo, [5.0], []; stride=1)
             @test isnan(DecisionRules._target_violation_share(0.0, 0.0))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -339,6 +339,151 @@ end
         @test objective_value(model6) ≈ 2510.0 rtol=1.0e-2
     end
 
+    @testset "sample logger and per-batch record" begin
+        function build_two_stage()
+            sp1, si1, so1, sov1, u1 = build_subproblem(10; subproblem=DiffOpt.conic_diff_model(Ipopt.Optimizer))
+            sp2, si2, so2, sov2, u2 = build_subproblem(10; state_i_val=1.0, state_out_val=9.0, subproblem=DiffOpt.conic_diff_model(Ipopt.Optimizer))
+            sps = [sp1, sp2]
+            spi = Vector{Vector{Any}}(undef, 2)
+            spi .= [[si1], [si2]]
+            spo = Vector{Vector{Tuple{Any, VariableRef}}}(undef, 2)
+            spo .= [[(so1, sov1)], [(so2, sov2)]]
+            usamples = [[(u1, [2.0])], [(u2, [1.0])]]
+            return sps, spi, spo, usamples
+        end
+
+        @testset "default path caches both metrics per sample" begin
+            sps, spi, spo, usamples = build_two_stage()
+            Random.seed!(222)
+            m = Chain(Dense(2, 4), Dense(4, 1))
+            recorded = []
+            sl = SampleLog()
+            train_multistage(m, [5.0], sps, spi, spo, usamples;
+                num_batches=2, num_train_per_batch=2, sample_log=sl,
+                record=(sample_log, iter, model) -> begin
+                    push!(recorded, (iter,
+                        copy(sample_log.objectives),
+                        copy(sample_log.objectives_no_deficit),
+                        sum(objective_value, sps) == sample_log.objectives[end],
+                        DecisionRules.get_objective_no_target_deficit(sps) == sample_log.objectives_no_deficit[end]))
+                    return false
+                end)
+            @test length(recorded) == 2
+            for (iter, objs, objs_nd, obj_matches, nd_matches) in recorded
+                @test length(objs) == 2 && length(objs_nd) == 2   # cache cleared per batch
+                @test all(isfinite, objs) && all(isfinite, objs_nd)
+                @test all(objs_nd .<= objs .+ 1.0e-6)             # slack penalty is nonnegative
+                @test obj_matches                                  # cache equals re-read of the live models
+                @test nd_matches
+            end
+            @test default_record(sl, 1, m) == false
+        end
+
+        @testset "deterministic-equivalent overload caches per sample" begin
+            sps, spi, spo, usamples = build_two_stage()
+            det_equivalent, usamples_det = DecisionRules.deterministic_equivalent!(
+                DiffOpt.nonlinear_diff_model(Ipopt.Optimizer),
+                sps, spi, spo, [5.0], usamples)
+            Random.seed!(222)
+            m = Chain(Dense(2, 10), Dense(10, 1))
+            recorded = []
+            train_multistage(m, [5.0], det_equivalent, spi, spo, usamples_det;
+                num_batches=2, num_train_per_batch=2,
+                record=(sample_log, iter, model) -> begin
+                    push!(recorded, (length(sample_log.objectives),
+                        sample_log.objectives[end] == objective_value(det_equivalent),
+                        sample_log.objectives_no_deficit[end] ==
+                            DecisionRules.get_objective_no_target_deficit(det_equivalent)))
+                    return false
+                end)
+            @test length(recorded) == 2
+            for (n, obj_matches, nd_matches) in recorded
+                @test n == 2          # cache cleared per batch
+                @test obj_matches     # cache equals re-read of the live det-eq model
+                @test nd_matches
+            end
+        end
+
+        @testset "per-sample hook fires with the live models" begin
+            sps, spi, spo, usamples = build_two_stage()
+            Random.seed!(222)
+            m = Chain(Dense(2, 4), Dense(4, 1))
+            hook_calls = []
+            sl = SampleLog(on_sample=(s, models, log) -> push!(hook_calls, (s, termination_status(models[1]))))
+            train_multistage(m, [5.0], sps, spi, spo, usamples;
+                num_batches=1, num_train_per_batch=3, sample_log=sl,
+                record=(sample_log, iter, model) -> false)
+            @test [c[1] for c in hook_calls] == [1, 2, 3]
+            @test all(c[2] == MOI.LOCALLY_SOLVED for c in hook_calls)
+        end
+
+        @testset "record early-stop contract" begin
+            sps, spi, spo, usamples = build_two_stage()
+            Random.seed!(222)
+            m = Chain(Dense(2, 4), Dense(4, 1))
+            batches_seen = Ref(0)
+            train_multistage(m, [5.0], sps, spi, spo, usamples;
+                num_batches=5, num_train_per_batch=1,
+                record=(sample_log, iter, model) -> begin
+                    batches_seen[] += 1
+                    return true
+                end)
+            @test batches_seen[] == 1
+        end
+
+        @testset "deprecated record_loss adapter" begin
+            sps, spi, spo, usamples = build_two_stage()
+            Random.seed!(222)
+            m = Chain(Dense(2, 4), Dense(4, 1))
+            calls = []
+            train_multistage(m, [5.0], sps, spi, spo, usamples;
+                num_batches=2, num_train_per_batch=1,
+                record_loss=(iter, model, loss, tag) -> begin
+                    push!(calls, tag)
+                    return false
+                end)
+            @test calls == ["metrics/loss", "metrics/training_loss", "metrics/loss", "metrics/training_loss"]
+            # a stop requested on the first call short-circuits the second, as historically
+            calls2 = []
+            train_multistage(m, [5.0], sps, spi, spo, usamples;
+                num_batches=3, num_train_per_batch=1,
+                record_loss=(iter, model, loss, tag) -> begin
+                    push!(calls2, tag)
+                    return true
+                end)
+            @test calls2 == ["metrics/loss"]
+            @test_throws ArgumentError train_multistage(m, [5.0], sps, spi, spo, usamples;
+                num_batches=1, num_train_per_batch=1,
+                record=(sample_log, iter, model) -> false,
+                record_loss=(iter, model, loss, tag) -> false)
+        end
+
+        @testset "RolloutEvaluation on a fixed scenario set" begin
+            sps, spi, spo, usamples = build_two_stage()
+            Random.seed!(222)
+            scenarios = [DecisionRules.sample(usamples) for _ in 1:2]
+            # A policy on the reachable frontier: y <= 8 with x + y >= 10 forces x >= 2,
+            # so the largest reachable state_out is state_in + uncertainty - 2. The policy
+            # input is [uncertainty..., previous_state...], hence the target below is
+            # exactly reachable at every stage and the violation share is ~0 by
+            # construction.
+            reachable_policy = x -> [x[1] + x[2] - 2.0]
+            rollout_eval = RolloutEvaluation(sps, spi, spo, [5.0], scenarios; stride=1,
+                record=(sample_log, iter, model) -> false)
+            @test rollout_eval(SampleLog(), 1, reachable_policy) == false
+            @test isfinite(rollout_eval.last_objective_no_deficit)
+            @test abs(rollout_eval.last_violation_share) < 1.0e-4
+            # stride: no evaluation on off-stride batches
+            rollout_eval2 = RolloutEvaluation(sps, spi, spo, [5.0], scenarios; stride=2,
+                record=(sample_log, iter, model) -> false)
+            rollout_eval2(SampleLog(), 1, reachable_policy)
+            @test isnan(rollout_eval2.last_objective_no_deficit)
+            @test_throws ArgumentError RolloutEvaluation(sps, spi, spo, [5.0], []; stride=1)
+            @test isnan(DecisionRules._target_violation_share(0.0, 0.0))
+            @test DecisionRules._target_violation_share(200.0, 150.0) ≈ 0.25
+        end
+    end
+
     @testset "StateConditionedPolicy" begin
         # Test construction
         n_uncertainty = 5


### PR DESCRIPTION
Fixes #42

This implements the sample-logger + single per-batch `record` design proposed in the issue thread.

## Summary

Deterministic-equivalent evaluation can overstate policy quality: the coupled solve re-optimizes all stages
jointly and absorbs stage-wise-unfollowable targets through the slack penalty. This PR (1) restructures the
recording API of `train_multistage` around a per-sample sample logger and a single per-batch record call, as
proposed in the issue comment, and (2) ships a ready-made record implementation that evaluates the policy
with a stage-wise rollout (deployment semantics) on a fixed held-out scenario set and reports an
operational-cost metric plus a target-violation share.

## What changed

- `src/utils.jl`: `SampleLog` — a callable struct patterned after `SaveBest` that keeps a per-batch cache;
  the training loops call `sample_log(s, det_equivalent_or_subproblems)` right after each sample's solve.
  By default it caches the full objective and the objective excluding the target-slack penalty; an
  `on_sample(s, models, sample_log)` hook enables sample-wise debugging against the live JuMP models
  (statuses, suspicious-sample dumps) with no default per-sample logging cost.
- `src/simulate_multistage.jl` (both `train_multistage` overloads; positional arguments unchanged): the
  hardcoded `get_objective_no_target_deficit` accumulation inside the gradient closure is replaced by the
  sample-log call, and the two per-batch `record_loss(iter, model, loss, tag)` invocations are replaced by
  one `record(sample_log, iter, model)`; a `true` return stops training, as before.
- Backward compatibility: the default `record` reproduces the historical console output and metric values
  (same floating-point accumulation order). An explicitly passed legacy `record_loss` keyword keeps working
  through a deprecation adapter that preserves the historical two-call short-circuit ("metrics/loss" first;
  a stop there suppresses the "metrics/training_loss" call). Passing both `record` and `record_loss` is an
  error. Untouched examples that pass `record_loss` continue to work.
- `RolloutEvaluation` (`src/utils.jl`): a record implementation that, every `stride` batches, rolls the
  policy out stage by stage over a fixed, materialized held-out scenario set and reports (a) the rollout
  objective excluding the target-slack penalty term (operational cost) and (b) the target-violation share
  (realized slack penalty / full objective; `NaN` when undefined). Comparisons should only be trusted when
  the share is ≤ ~0.05 — documented in the docstring and README.
- `examples/HydroPowerModels/train_dr_hydropowermodels_subproblems.jl` is wired to the new record API
  (checkpointing/stalling still fed the mean full training objective) with the rollout evaluation on a
  fixed held-out set; README gains an "Evaluation" section with a usage snippet.
- `test/runtests.jl`: cache-vs-live-model equality on the package test problem, per-sample hook firing,
  early-stop contract, legacy-adapter call order + short-circuit + both-kwargs error, fixed-set rollout
  metrics with a reachable-target policy (violation share ~0 by construction), and share edge-case guards.
- `train_multiple_shooting` is intentionally not converted in this PR (it has its own out-of-gradient
  evaluation loop); follow-up material if desired.

## Validation

- `Pkg.test()` green on this branch (189/189, includes the new testsets).
- Reduced-scale demo (Bolivia DCP, 12 stages, 100 batches, vanilla Ipopt, fixed 4-scenario held-out set,
  stride 10): during constant-penalty deterministic-equivalent training, `RolloutEvaluation` reports the
  rollout operational cost and the target-violation share live every 10 batches. The det-eq training
  metric falls from 40.6k to 22.8k (with small fluctuations) while the violation share stays far outside
  the trust gate
  (0.95 -> 0.57 over the run) — exactly the situation where the guard tells you not to trust the
  deterministic-equivalent picture yet.

## Notes

- The shape of the recording API changes (single `record(sample_log, iter, model)` per batch instead of two
  4-argument `record_loss` calls) — as proposed by the maintainer in the issue thread; the deprecation
  adapter keeps explicitly-passed `record_loss` callbacks working unchanged.
- Note: this PR and #41/#42 both touch
  `examples/HydroPowerModels/train_dr_hydropowermodels_subproblems.jl`; whichever merges second will be
  rebased onto the other.
